### PR TITLE
Use  guzzlehttp/psr7 instead of fix guzzle version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require": {
         "silverstripe/framework": "^4.0",
-        "guzzlehttp/guzzle": "^6.3"
+        "guzzlehttp/psr7": "^2"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",


### PR DESCRIPTION
so we can install that module with Silverstripe 4.11+
fixes #5 